### PR TITLE
fix(charts): Added extraLBAnnotations and fixed mismatched ports

### DIFF
--- a/helm-charts/k8s-mediaserver/templates/storage-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/storage-resources.yml
@@ -168,3 +168,30 @@ spec:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{- with .Values.prowlarr.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
In partial response to #71 

The extraLBService should now be a simple true/false and annotations can be added by specifying extraLBAnnotations